### PR TITLE
Generic instance based on ISO 8601 representation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "purescript-enums": "^0.7.0",
     "purescript-functions": "^0.1.0",
-    "purescript-globals": "^0.2.0"
+    "purescript-globals": "^0.2.0",
+    "purescript-generics": "~0.6.2"
   }
 }

--- a/src/Data/Date.purs
+++ b/src/Data/Date.purs
@@ -24,6 +24,7 @@ import Control.Monad.Eff
 import Data.Enum (Enum, Cardinality(..), fromEnum, defaultSucc, defaultPred)
 import Data.Function (on, Fn2(), runFn2, Fn3(), runFn3)
 import Data.Maybe (Maybe(..))
+import Data.Generic
 import Data.Time
 
 -- | A native JavaScript `Date` object.
@@ -36,11 +37,18 @@ foreign import data JSDate :: *
 -- | modules.
 newtype Date = DateTime JSDate
 
+instance genericDate :: Generic Date where
+  toSpine d = SString (runFn2 jsDateMethod "toISOString" (toJSDate d))
+  toSignature _ = SigString
+  fromSpine (SString s) = fromStringStrict s
+  fromSpine _ = Nothing
+
+
 instance eqDate :: Eq Date where
-  eq = eq `on` toEpochMilliseconds
+  eq = gEq
 
 instance ordDate :: Ord Date where
-  compare = compare `on` toEpochMilliseconds
+  compare = gCompare
 
 instance showDate :: Show Date where
   show d = "(fromEpochMilliseconds " ++ show (toEpochMilliseconds d) ++ ")"


### PR DESCRIPTION
This is something I'm really wanting in my own application. I can newtype around, but this seems suitably useful and general that it might want to be included in the date definition.

Another useful instance would be `IsForeign` -- I can implement and make a PR for that if wanted :)