### PR TITLE
Remove unused import

### DIFF
--- a/src/Data/Time.purs
+++ b/src/Data/Time.purs
@@ -6,7 +6,6 @@ import Prelude
   , (++)
   , (-)
   , (/)
-  , (/=)
   , (==)
   , DivisionRing
   , Eq


### PR DESCRIPTION
The PureScript compiler warns about unused imports as of 0.7.6.