### PR TITLE
Derive generic

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "purescript-enums": "^0.7.0",
     "purescript-functions": "^0.1.0",
-    "purescript-globals": "^0.2.0"
+    "purescript-globals": "^0.2.0",
+    "purescript-generics": "~0.6.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,6 @@
     "purescript-enums": "^0.7.0",
     "purescript-functions": "^0.1.0",
     "purescript-globals": "^0.2.0",
-    "purescript-generics": "~0.6.2"
+    "purescript-generics": "^0.7.0"
   }
 }

--- a/src/Data/Date.purs
+++ b/src/Data/Date.purs
@@ -20,7 +20,8 @@ module Data.Date
 
 import Prelude
 
-import Control.Monad
+import Type.Proxy
+
 import Control.Monad.Eff
 import Data.Enum (Enum, Cardinality(..), fromEnum, defaultSucc, defaultPred)
 import Data.Function (on, Fn2(), runFn2, Fn3(), runFn3)
@@ -40,7 +41,7 @@ newtype Date = DateTime JSDate
 
 instance genericDate :: Generic Date where
   toSpine d = SProd "Date" [const (toSpine $ toEpochMilliseconds d)]
-  toSignature _ = SigProd [{ sigConstructor: "Date", sigValues: [const $ toSignature (anyProxy :: Proxy Milliseconds)] }]
+  toSignature _ = SigProd "Date" [{ sigConstructor: "Date", sigValues: [const $ toSignature (Proxy :: Proxy Milliseconds)] }]
   fromSpine (SProd "Date" [msf]) = fromSpine (msf unit) >>= fromEpochMilliseconds
   fromSpine _                    = Nothing
 

--- a/src/Data/Date.purs
+++ b/src/Data/Date.purs
@@ -103,12 +103,16 @@ foreign import nowEpochMilliseconds :: forall e. Eff (now :: Now | e) Millisecon
 -- | A timezone locale offset, measured in minutes.
 newtype LocaleOffset = LocaleOffset Minutes
 
+derive instance genericLocaleOffset :: Generic LocaleOffset
+
 -- | Get the locale time offset for a `Date`.
 timezoneOffset :: Date -> LocaleOffset
 timezoneOffset (DateTime d) = runFn2 jsDateMethod "getTimezoneOffset" d
 
 -- | A year date component value.
 newtype Year = Year Int
+
+derive instance genericYear :: Generic Year
 
 instance eqYear :: Eq Year where
   eq (Year x) (Year y) = x == y
@@ -142,6 +146,8 @@ data Month
   | October
   | November
   | December
+
+derive instance genericMonth :: Generic Month
 
 instance eqMonth :: Eq Month where
   eq January   January   = true
@@ -220,6 +226,8 @@ monthFromEnum December  = 11
 -- | A day-of-month date component value.
 newtype DayOfMonth = DayOfMonth Int
 
+derive instance genericDayOfMonth :: Generic DayOfMonth
+
 instance eqDayOfMonth :: Eq DayOfMonth where
   eq (DayOfMonth x) (DayOfMonth y) = x == y
 
@@ -235,6 +243,8 @@ data DayOfWeek
   | Thursday
   | Friday
   | Saturday
+
+derive instance genericDayOfWeek :: Generic DayOfWeek
 
 instance eqDayOfWeek :: Eq DayOfWeek where
   eq Sunday    Sunday    = true

--- a/src/Data/Date.purs
+++ b/src/Data/Date.purs
@@ -20,11 +20,13 @@ module Data.Date
 
 import Prelude
 
+import Control.Monad
 import Control.Monad.Eff
 import Data.Enum (Enum, Cardinality(..), fromEnum, defaultSucc, defaultPred)
 import Data.Function (on, Fn2(), runFn2, Fn3(), runFn3)
 import Data.Maybe (Maybe(..))
 import Data.Time
+import Data.Generic
 
 -- | A native JavaScript `Date` object.
 foreign import data JSDate :: *
@@ -35,6 +37,12 @@ foreign import data JSDate :: *
 -- | and `dateTime` functions in the `Data.Date.Locale` and `Data.Date.UTC`
 -- | modules.
 newtype Date = DateTime JSDate
+
+instance genericDate :: Generic Date where
+  toSpine d = SProd "Date" [const (toSpine $ toEpochMilliseconds d)]
+  toSignature _ = SigProd [{ sigConstructor: "Date", sigValues: [const $ toSignature (anyProxy :: Proxy Milliseconds)] }]
+  fromSpine (SProd "Date" [msf]) = fromSpine (msf unit) >>= fromEpochMilliseconds
+  fromSpine _                    = Nothing
 
 instance eqDate :: Eq Date where
   eq = eq `on` toEpochMilliseconds

--- a/src/Data/Time.purs
+++ b/src/Data/Time.purs
@@ -18,9 +18,13 @@ import Prelude
   , compare
   , show )
 
+import Data.Generic
+
 -- | An hour component from a time value. Should fall between 0 and 23
 -- | inclusive.
 newtype HourOfDay = HourOfDay Int
+
+derive instance genericHourOfDay :: Generic HourOfDay
 
 instance eqHourOfDay :: Eq HourOfDay where
   eq (HourOfDay x) (HourOfDay y) = x == y
@@ -30,6 +34,8 @@ instance ordHourOfDay :: Ord HourOfDay where
 
 -- | A quantity of hours (not necessarily a value between 0 and 23).
 newtype Hours = Hours Number
+
+derive instance genericHours :: Generic Hours
 
 instance eqHours :: Eq Hours where
   eq (Hours x) (Hours y) = x == y
@@ -61,6 +67,8 @@ instance showHours :: Show Hours where
 -- | inclusive.
 newtype MinuteOfHour = MinuteOfHour Int
 
+derive instance genericMinuteOfHour :: Generic MinuteOfHour
+
 instance eqMinuteOfHour :: Eq MinuteOfHour where
   eq (MinuteOfHour x) (MinuteOfHour y) = x == y
 
@@ -69,6 +77,8 @@ instance ordMinuteOfHour :: Ord MinuteOfHour where
 
 -- | A quantity of minutes (not necessarily a value between 0 and 60).
 newtype Minutes = Minutes Number
+
+derive instance genericMinutes :: Generic Minutes
 
 instance eqMinutes :: Eq Minutes where
   eq (Minutes x) (Minutes y) = x == y
@@ -100,6 +110,8 @@ instance showMinutes :: Show Minutes where
 -- | inclusive.
 newtype SecondOfMinute = SecondOfMinute Int
 
+derive instance genericSecondOfMinute :: Generic SecondOfMinute
+
 instance eqSecondOfMinute :: Eq SecondOfMinute where
   eq (SecondOfMinute x) (SecondOfMinute y) = x == y
 
@@ -108,6 +120,8 @@ instance ordSecondOfMinute :: Ord SecondOfMinute where
 
 -- | A quantity of seconds (not necessarily a value between 0 and 60).
 newtype Seconds = Seconds Number
+
+derive instance genericSeconds :: Generic Seconds
 
 instance eqSeconds :: Eq Seconds where
   eq (Seconds x) (Seconds y) = x == y
@@ -139,6 +153,8 @@ instance showSeconds :: Show Seconds where
 -- | inclusive.
 newtype MillisecondOfSecond = MillisecondOfSecond Int
 
+derive instance genericMillisecondOfSecond :: Generic MillisecondOfSecond
+
 instance eqMillisecondOfSecond :: Eq MillisecondOfSecond where
   eq (MillisecondOfSecond x) (MillisecondOfSecond y) = x == y
 
@@ -147,6 +163,8 @@ instance ordMillisecondOfSecond :: Ord MillisecondOfSecond where
 
 -- | A quantity of milliseconds (not necessarily a value between 0 and 1000).
 newtype Milliseconds = Milliseconds Number
+
+derive instance genericMilliseconds :: Generic Milliseconds
 
 instance eqMilliseconds :: Eq Milliseconds where
   eq (Milliseconds x) (Milliseconds y) = x == y


### PR DESCRIPTION
Continuation of #22. All I added was generic deriving for the rest of the types in src/Date. I added some question in #22, so I guess I'll add them here as well to maybe keep the discussion going.

What offset/timezone support do you think would be most beneficial? Is it the plan here to incorporate this whole body of (notoriously tricky) offset/timezone logic like a library like moment.js does?

Would it be a possibility to merge this PR as it is now and hold off on the move to a newtype around Milliseconds + timezone/offset? Or do you think that's a bad idea?