### PR TITLE
Note how to create instances of this type

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ bower install purescript-datetime
 
 ## Documentation
 
-This libary provides platform-independent representations of date and time. Parsing specific date formats, such as the ISO 8601 format, is the responsibility of other libraries, such as the [purescript-js-date](https://github.com/purescript-contrib/purescript-js-date) package.
+This libary provides platform-independent representations of date and time. Parsing specific date formats, such as the ISO 8601 format, is the responsibility of other libraries, such as the [purescript-js-date](https://github.com/purescript-contrib/purescript-js-date) package. Likewise, writing a date/time type to string to display to humans is the responsibility of other libraries, such as the [purescript-formatters](https://github.com/slamdata/purescript-formatters) package.
 
 Module documentation is [published on Pursuit](http://pursuit.purescript.org/packages/purescript-datetime).

--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ bower install purescript-datetime
 
 ## Documentation
 
+This libary provides platform-independent representations of date and time. Parsing specific date formats, such as the ISO 8601 format, is the responsibility of other libraries, such as the [purescript-js-date](https://github.com/purescript-contrib/purescript-js-date) package.
+
 Module documentation is [published on Pursuit](http://pursuit.purescript.org/packages/purescript-datetime).


### PR DESCRIPTION
This question has come up many times, so we need to improve documentation.

Here's from today:
> given an ISO 8601 datetime string, eg “2016-07-22T01:00:00Z”, how can I create a  purescript-datetime DateTime value? It’s probably a good idea to add a note to its documentation regarding conversion to/from iso strings."