### PR TITLE
Add isLeapYear function

### DIFF
--- a/src/Data/Date.purs
+++ b/src/Data/Date.purs
@@ -7,6 +7,7 @@ module Data.Date
   , day
   , weekday
   , diff
+  , isLeapYear
   , module Data.Date.Component
   ) where
 
@@ -75,6 +76,12 @@ weekday = unsafePartial \(Date y m d) ->
 diff :: forall d. Duration d => Date -> Date -> d
 diff (Date y1 m1 d1) (Date y2 m2 d2) =
   toDuration $ runFn6 calcDiff y1 (fromEnum m1) d1 y2 (fromEnum m2) d2
+
+-- | Is this year a leap year according to the proleptic Gregorian calendar?
+isLeapYear :: Year -> Boolean
+isLeapYear y = (mod y' 4 == 0) && ((mod y' 400 == 0) || not (mod y' 100 == 0))
+  where
+  y' = fromEnum y
 
 -- TODO: these could (and probably should) be implemented in PS
 foreign import canonicalDateImpl :: Fn4 (Year -> Int -> Day -> Date) Year Int Day Date

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -1,24 +1,22 @@
 module Test.Main where
 
 import Prelude
-
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE, log)
-
-import Data.Enum (class BoundedEnum, Cardinality, toEnum, enumFromTo, cardinality, succ, fromEnum, pred)
-import Data.Date as Date
-import Data.Time as Time
-import Data.Time.Duration as Duration
 import Data.Array as Array
+import Data.Date as Date
 import Data.DateTime as DateTime
 import Data.DateTime.Instant as Instant
+import Data.Time as Time
+import Data.Time.Duration as Duration
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+import Data.Date (isLeapYear)
+import Data.Enum (class BoundedEnum, Cardinality, toEnum, enumFromTo, cardinality, succ, fromEnum, pred)
 import Data.Maybe (Maybe(..), fromJust)
-import Data.Tuple (Tuple(..), snd)
 import Data.Newtype (unwrap)
-
-import Type.Proxy (Proxy(..))
-import Test.Assert (ASSERT, assert)
+import Data.Tuple (Tuple(..), snd)
 import Partial.Unsafe (unsafePartial)
+import Test.Assert (ASSERT, assert)
+import Type.Proxy (Proxy(..))
 
 type Tests = Eff (console :: CONSOLE, assert :: ASSERT) Unit
 
@@ -97,6 +95,12 @@ main = do
 
   log "Check that diff behaves as expected"
   assert $ Date.diff d2 d1 == Duration.Days 29.0
+
+  let unsafeYear = unsafePartial fromJust <<< toEnum
+  log "Check that isLeapYear behaves as expected"
+  assert $ not $ isLeapYear (unsafeYear 2017)
+  assert $ isLeapYear (unsafeYear 2016)
+
 
   -- datetime ----------------------------------------------------------------
 

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -1,22 +1,24 @@
 module Test.Main where
 
 import Prelude
-import Data.Array as Array
-import Data.Date as Date
-import Data.DateTime as DateTime
-import Data.DateTime.Instant as Instant
-import Data.Time as Time
-import Data.Time.Duration as Duration
+
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
-import Data.Date (isLeapYear)
+
 import Data.Enum (class BoundedEnum, Cardinality, toEnum, enumFromTo, cardinality, succ, fromEnum, pred)
+import Data.Date as Date
+import Data.Time as Time
+import Data.Time.Duration as Duration
+import Data.Array as Array
+import Data.DateTime as DateTime
+import Data.DateTime.Instant as Instant
 import Data.Maybe (Maybe(..), fromJust)
-import Data.Newtype (unwrap)
 import Data.Tuple (Tuple(..), snd)
-import Partial.Unsafe (unsafePartial)
-import Test.Assert (ASSERT, assert)
+import Data.Newtype (unwrap)
+
 import Type.Proxy (Proxy(..))
+import Test.Assert (ASSERT, assert)
+import Partial.Unsafe (unsafePartial)
 
 type Tests = Eff (console :: CONSOLE, assert :: ASSERT) Unit
 
@@ -98,8 +100,8 @@ main = do
 
   let unsafeYear = unsafePartial fromJust <<< toEnum
   log "Check that isLeapYear behaves as expected"
-  assert $ not $ isLeapYear (unsafeYear 2017)
-  assert $ isLeapYear (unsafeYear 2016)
+  assert $ not $ Date.isLeapYear (unsafeYear 2017)
+  assert $ Date.isLeapYear (unsafeYear 2016)
 
 
   -- datetime ----------------------------------------------------------------


### PR DESCRIPTION
I may be building a calendar display using this library, so this is
one of the functions I'll need.

Looks like psc-ide-add-import may have shifted the contents of the imports. Hope that's alright.