### PR TITLE
Export `fromDate`

### DIFF
--- a/src/Data/DateTime/Instant.purs
+++ b/src/Data/DateTime/Instant.purs
@@ -3,6 +3,7 @@ module Data.DateTime.Instant
   , instant
   , unInstant
   , fromDateTime
+  , fromDate
   , toDateTime
   ) where
 


### PR DESCRIPTION
So `fromDate` exists, but is not used in any other function in the module, and it's not exported. Which means it's effectively dead code. Considering this function happens to be useful to me, I think exporting it will be useful.