### PR TITLE
Use purescript-generics-rep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "purescript-assert": "^3.0.0",
     "purescript-console": "^3.0.0",
-    "purescript-strings": "^3.0.0"
+    "purescript-strings": "^3.0.0",
+    "purescript-typelevel": "^3.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "purescript-enums": "^3.1.0",
     "purescript-functions": "^3.0.0",
-    "purescript-generics": "^4.0.0",
+    "purescript-generics-rep": "^5.3.0",
     "purescript-integers": "^3.0.0",
     "purescript-foldable-traversable": "^3.0.0",
     "purescript-maps": "^3.0.0",

--- a/src/Data/Date.purs
+++ b/src/Data/Date.purs
@@ -17,7 +17,7 @@ import Prelude
 import Data.Date.Component (Day, Month(..), Weekday(..), Year)
 import Data.Enum (toEnum, fromEnum)
 import Data.Function.Uncurried (Fn3, runFn3, Fn4, runFn4, Fn6, runFn6)
-import Data.Generic (class Generic)
+import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Time.Duration (class Duration, toDuration, Milliseconds)
 
@@ -45,7 +45,7 @@ exactDate y m d =
 
 derive instance eqDate :: Eq Date
 derive instance ordDate :: Ord Date
-derive instance genericDate :: Generic Date
+derive instance genericDate :: Generic Date _
 
 instance boundedDate :: Bounded Date where
   bottom = Date bottom bottom bottom

--- a/src/Data/Date.purs
+++ b/src/Data/Date.purs
@@ -17,7 +17,6 @@ import Prelude
 import Data.Date.Component (Day, Month(..), Weekday(..), Year)
 import Data.Enum (toEnum, fromEnum)
 import Data.Function.Uncurried (Fn3, runFn3, Fn4, runFn4, Fn6, runFn6)
-import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Time.Duration (class Duration, toDuration, Milliseconds)
 
@@ -45,7 +44,6 @@ exactDate y m d =
 
 derive instance eqDate :: Eq Date
 derive instance ordDate :: Ord Date
-derive instance genericDate :: Generic Date _
 
 instance boundedDate :: Bounded Date where
   bottom = Date bottom bottom bottom

--- a/src/Data/Date/Component.purs
+++ b/src/Data/Date/Component.purs
@@ -8,7 +8,7 @@ module Data.Date.Component
 import Prelude
 
 import Data.Enum (class Enum, class BoundedEnum, toEnum, fromEnum, Cardinality(..))
-import Data.Generic (class Generic)
+import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..))
 
 -- | A year component for a date.
@@ -20,7 +20,7 @@ newtype Year = Year Int
 
 derive newtype instance eqYear :: Eq Year
 derive newtype instance ordYear :: Ord Year
-derive instance genericYear :: Generic Year
+derive instance genericYear :: Generic Year _
 
 -- Note: these seemingly arbitrary bounds come from relying on JS for date
 -- manipulations, as it only supports date ±100,000,000 days of the Unix epoch.
@@ -61,7 +61,7 @@ data Month
 
 derive instance eqMonth :: Eq Month
 derive instance ordMonth :: Ord Month
-derive instance genericMonth :: Generic Month
+derive instance genericMonth :: Generic Month _
 
 instance boundedMonth :: Bounded Month where
   bottom = January
@@ -124,7 +124,7 @@ newtype Day = Day Int
 
 derive newtype instance eqDay :: Eq Day
 derive newtype instance ordDay :: Ord Day
-derive instance genericDay :: Generic Day
+derive instance genericDay :: Generic Day _
 
 instance boundedDay :: Bounded Day where
   bottom = Day 1
@@ -156,7 +156,7 @@ data Weekday
 
 derive instance eqWeekday :: Eq Weekday
 derive instance ordWeekday :: Ord Weekday
-derive instance genericWeekday :: Generic Weekday
+derive instance genericWeekday :: Generic Weekday _
 
 instance boundedWeekday :: Bounded Weekday where
   bottom = Monday

--- a/src/Data/Date/Component.purs
+++ b/src/Data/Date/Component.purs
@@ -20,7 +20,6 @@ newtype Year = Year Int
 
 derive newtype instance eqYear :: Eq Year
 derive newtype instance ordYear :: Ord Year
-derive instance genericYear :: Generic Year _
 
 -- Note: these seemingly arbitrary bounds come from relying on JS for date
 -- manipulations, as it only supports date ±100,000,000 days of the Unix epoch.
@@ -124,7 +123,6 @@ newtype Day = Day Int
 
 derive newtype instance eqDay :: Eq Day
 derive newtype instance ordDay :: Ord Day
-derive instance genericDay :: Generic Day _
 
 instance boundedDay :: Bounded Day where
   bottom = Day 1

--- a/src/Data/DateTime.purs
+++ b/src/Data/DateTime.purs
@@ -17,7 +17,7 @@ import Prelude
 import Data.Date (Date, Day, Month(..), Weekday(..), Year, canonicalDate, day, exactDate, month, weekday, year)
 import Data.Enum (toEnum, fromEnum)
 import Data.Function.Uncurried (Fn2, runFn2)
-import Data.Generic (class Generic)
+import Data.Generic.Rep (class Generic)
 import Data.Time (Hour, Millisecond, Minute, Second, Time(..), hour, setHour, millisecond, setMillisecond, minute, setMinute, second, setSecond)
 import Data.Time.Duration (class Duration, fromDuration, toDuration, Milliseconds)
 import Data.Maybe (Maybe(..))
@@ -27,7 +27,7 @@ data DateTime = DateTime Date Time
 
 derive instance eqDateTime :: Eq DateTime
 derive instance ordDateTime :: Ord DateTime
-derive instance genericDateTime :: Generic DateTime
+derive instance genericDateTime :: Generic DateTime _
 
 instance boundedDateTime :: Bounded DateTime where
   bottom = DateTime bottom bottom

--- a/src/Data/DateTime/Instant.purs
+++ b/src/Data/DateTime/Instant.purs
@@ -12,7 +12,7 @@ import Prelude
 import Data.DateTime (Millisecond, Second, Minute, Hour, Day, Year, DateTime(..), Date, Time(..), canonicalDate, millisecond, second, minute, hour, day, month, year)
 import Data.Enum (fromEnum, toEnum)
 import Data.Function.Uncurried (Fn7, runFn7)
-import Data.Generic (class Generic)
+import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Time.Duration (Milliseconds(..))
 
@@ -27,7 +27,7 @@ newtype Instant = Instant Milliseconds
 
 derive newtype instance eqDateTime :: Eq Instant
 derive newtype instance ordDateTime :: Ord Instant
-derive instance genericDateTime :: Generic Instant
+derive instance genericDateTime :: Generic Instant _
 
 instance boundedInstant :: Bounded Instant where
   bottom = Instant (Milliseconds (-8639977881600000.0))

--- a/src/Data/DateTime/Locale.purs
+++ b/src/Data/DateTime/Locale.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Comonad (class Comonad, class Extend)
 import Data.DateTime (Date, Time, DateTime)
 import Data.Foldable (class Foldable)
-import Data.Generic (class Generic)
+import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
 import Data.Time.Duration (Minutes)
@@ -16,7 +16,7 @@ data Locale = Locale (Maybe LocaleName) Minutes
 
 derive instance eqLocale :: Eq Locale
 derive instance ordLocale :: Ord Locale
-derive instance genericLocale :: Generic Locale
+derive instance genericLocale :: Generic Locale _
 
 instance showLocale :: Show Locale where
   show (Locale name offset) = "(Locale " <> show name <> " " <> show offset <> ")"
@@ -27,7 +27,7 @@ newtype LocaleName = LocaleName String
 derive instance newtypeLocaleName :: Newtype LocaleName _
 derive newtype instance eqLocaleName :: Eq LocaleName
 derive newtype instance ordLocaleName :: Ord LocaleName
-derive instance genericLocaleName :: Generic LocaleName
+derive instance genericLocaleName :: Generic LocaleName _
 
 instance showLocaleName :: Show LocaleName where
   show (LocaleName name) = "(LocaleName " <> show name <> ")"
@@ -41,7 +41,7 @@ data LocalValue a = LocalValue Locale a
 
 derive instance eqLocalValue :: Eq a => Eq (LocalValue a)
 derive instance ordLocalValue :: Ord a => Ord (LocalValue a)
-derive instance genericLocalValue :: Generic a => Generic (LocalValue a)
+derive instance genericLocalValue :: Generic (LocalValue a) _
 
 instance showLocalValue :: Show a => Show (LocalValue a) where
   show (LocalValue n a) = "(LocalValue " <> show n <> " " <> show a <> ")"

--- a/src/Data/Time.purs
+++ b/src/Data/Time.purs
@@ -12,7 +12,7 @@ module Data.Time
 import Prelude
 
 import Data.Enum (fromEnum, toEnum)
-import Data.Generic (class Generic)
+import Data.Generic.Rep (class Generic)
 import Data.Int as Int
 import Data.Maybe (fromJust)
 import Data.Newtype (unwrap)
@@ -28,7 +28,7 @@ data Time = Time Hour Minute Second Millisecond
 
 derive instance eqTime :: Eq Time
 derive instance ordTime :: Ord Time
-derive instance genericTime :: Generic Time
+derive instance genericTime :: Generic Time _
 
 instance boundedTime :: Bounded Time where
   bottom = Time bottom bottom bottom bottom

--- a/src/Data/Time/Component.purs
+++ b/src/Data/Time/Component.purs
@@ -8,7 +8,7 @@ module Data.Time.Component
 import Prelude
 
 import Data.Enum (class Enum, class BoundedEnum, toEnum, fromEnum, Cardinality(..))
-import Data.Generic (class Generic)
+import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..))
 
 -- | An hour component for a time value.
@@ -21,7 +21,7 @@ newtype Hour = Hour Int
 
 derive newtype instance eqHour :: Eq Hour
 derive newtype instance ordHour :: Ord Hour
-derive instance genericHour :: Generic Hour
+derive instance genericHour :: Generic Hour _
 
 instance boundedHour :: Bounded Hour where
   bottom = Hour 0
@@ -51,7 +51,7 @@ newtype Minute = Minute Int
 
 derive newtype instance eqMinute :: Eq Minute
 derive newtype instance ordMinute :: Ord Minute
-derive instance genericMinute :: Generic Minute
+derive instance genericMinute :: Generic Minute _
 
 instance boundedMinute :: Bounded Minute where
   bottom = Minute 0
@@ -81,7 +81,7 @@ newtype Second = Second Int
 
 derive newtype instance eqSecond :: Eq Second
 derive newtype instance ordSecond :: Ord Second
-derive instance genericSecond :: Generic Second
+derive instance genericSecond :: Generic Second _
 
 instance boundedSecond :: Bounded Second where
   bottom = Second 0
@@ -112,7 +112,7 @@ newtype Millisecond = Millisecond Int
 
 derive newtype instance eqMillisecond :: Eq Millisecond
 derive newtype instance ordMillisecond :: Ord Millisecond
-derive instance genericMillisecond :: Generic Millisecond
+derive instance genericMillisecond :: Generic Millisecond _
 
 instance boundedMillisecond :: Bounded Millisecond where
   bottom = Millisecond 0

--- a/src/Data/Time/Component.purs
+++ b/src/Data/Time/Component.purs
@@ -8,7 +8,6 @@ module Data.Time.Component
 import Prelude
 
 import Data.Enum (class Enum, class BoundedEnum, toEnum, fromEnum, Cardinality(..))
-import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..))
 
 -- | An hour component for a time value.
@@ -21,7 +20,6 @@ newtype Hour = Hour Int
 
 derive newtype instance eqHour :: Eq Hour
 derive newtype instance ordHour :: Ord Hour
-derive instance genericHour :: Generic Hour _
 
 instance boundedHour :: Bounded Hour where
   bottom = Hour 0
@@ -51,7 +49,6 @@ newtype Minute = Minute Int
 
 derive newtype instance eqMinute :: Eq Minute
 derive newtype instance ordMinute :: Ord Minute
-derive instance genericMinute :: Generic Minute _
 
 instance boundedMinute :: Bounded Minute where
   bottom = Minute 0
@@ -81,7 +78,6 @@ newtype Second = Second Int
 
 derive newtype instance eqSecond :: Eq Second
 derive newtype instance ordSecond :: Ord Second
-derive instance genericSecond :: Generic Second _
 
 instance boundedSecond :: Bounded Second where
   bottom = Second 0
@@ -112,7 +108,6 @@ newtype Millisecond = Millisecond Int
 
 derive newtype instance eqMillisecond :: Eq Millisecond
 derive newtype instance ordMillisecond :: Ord Millisecond
-derive instance genericMillisecond :: Generic Millisecond _
 
 instance boundedMillisecond :: Bounded Millisecond where
   bottom = Millisecond 0

--- a/src/Data/Time/Duration.purs
+++ b/src/Data/Time/Duration.purs
@@ -2,14 +2,14 @@ module Data.Time.Duration where
 
 import Prelude
 
-import Data.Generic (class Generic)
+import Data.Generic.Rep (class Generic)
 import Data.Newtype (class Newtype, over)
 
 -- | A duration measured in milliseconds.
 newtype Milliseconds = Milliseconds Number
 
 derive instance newtypeMilliseconds :: Newtype Milliseconds _
-derive instance genericMilliseconds :: Generic Milliseconds
+derive instance genericMilliseconds :: Generic Milliseconds _
 derive newtype instance eqMilliseconds :: Eq Milliseconds
 derive newtype instance ordMilliseconds :: Ord Milliseconds
 derive newtype instance semiringMilliseconds :: Semiring Milliseconds
@@ -22,7 +22,7 @@ instance showMilliseconds :: Show Milliseconds where
 newtype Seconds = Seconds Number
 
 derive instance newtypeSeconds :: Newtype Seconds _
-derive instance genericSeconds :: Generic Seconds
+derive instance genericSeconds :: Generic Seconds _
 derive newtype instance eqSeconds :: Eq Seconds
 derive newtype instance ordSeconds :: Ord Seconds
 derive newtype instance semiringSeconds :: Semiring Seconds
@@ -35,7 +35,7 @@ instance showSeconds :: Show Seconds where
 newtype Minutes = Minutes Number
 
 derive instance newtypeMinutes :: Newtype Minutes _
-derive instance genericMinutes :: Generic Minutes
+derive instance genericMinutes :: Generic Minutes _
 derive newtype instance eqMinutes :: Eq Minutes
 derive newtype instance ordMinutes :: Ord Minutes
 derive newtype instance semiringMinutes :: Semiring Minutes
@@ -48,7 +48,7 @@ instance showMinutes :: Show Minutes where
 newtype Hours = Hours Number
 
 derive instance newtypeHours :: Newtype Hours _
-derive instance genericHours :: Generic Hours
+derive instance genericHours :: Generic Hours _
 derive newtype instance eqHours :: Eq Hours
 derive newtype instance ordHours :: Ord Hours
 derive newtype instance semiringHours :: Semiring Hours
@@ -61,7 +61,7 @@ instance showHours :: Show Hours where
 newtype Days = Days Number
 
 derive instance newtypeDays :: Newtype Days _
-derive instance genericDays :: Generic Days
+derive instance genericDays :: Generic Days _
 derive newtype instance eqDays :: Eq Days
 derive newtype instance ordDays :: Ord Days
 derive newtype instance semiringDays :: Semiring Days


### PR DESCRIPTION
pursescript-0.12 will not derive `Data.Generic`, this PR replaces it with `Data.Generic.Rep`.