### PR TITLE
Added enum instance for Date and date implementation of adjust

### DIFF
--- a/src/Data/Date.purs
+++ b/src/Data/Date.purs
@@ -20,7 +20,7 @@ import Data.Enum (class Enum, toEnum, fromEnum, succ, pred)
 import Data.Function.Uncurried (Fn3, runFn3, Fn4, runFn4, Fn6, runFn6)
 import Data.Int (fromNumber)
 import Data.Ord (abs)
-import Data.Maybe (Maybe(..), fromJust, fromMaybe, isNothing, maybe)
+import Data.Maybe (Maybe(..), fromJust, fromMaybe, isNothing)
 import Data.Time.Duration (class Duration, Days(..), Milliseconds, toDuration)
 import Partial.Unsafe (unsafePartial)
 
@@ -68,7 +68,7 @@ instance enumDate :: Enum Date where
       d' = if isNothing pd then Just l else pd
       m' = if isNothing pd then fromMaybe December pm else m
       y' = if isNothing pd && isNothing pm then pred y else Just y
-      pd = let v = pred d in if v < toEnum 1 then Nothing else v
+      pd = pred d
       pm = pred m
       l = lastDayOfMonth y m'
 
@@ -93,7 +93,7 @@ weekday = unsafePartial \(Date y m d) ->
 -- | Adjusts a date with a Duration in days. The day duration is
 -- | converted to an Int using fromNumber.
 adjust :: Days -> Date -> Maybe Date
-adjust (Days n) dt = maybe Nothing (\i -> go (abs i) (Just dt)) (fromNumber n)
+adjust (Days n) dt = fromNumber n >>= (\i -> go (abs i) (Just dt))
   where
     adj = if n < 0.0 then pred else succ
     go 0  dt' = dt'

--- a/src/Data/Date.purs
+++ b/src/Data/Date.purs
@@ -89,8 +89,9 @@ weekday = unsafePartial \(Date y m d) ->
   let n = runFn3 calcWeekday y (fromEnum m) d
   in if n == 0 then fromJust (toEnum 7) else fromJust (toEnum n)
 
--- | Adjusts a date with a Duration in days. The day duration is
--- | converted to an Int using fromNumber.
+-- | Adjusts a date with a Duration in days. The number of days must
+-- | fall within the valid range for an `Int` type otherwise `Nothing`
+-- | is returned.
 adjust :: Days -> Date -> Maybe Date
 adjust (Days n) date = fromNumber n >>= flip adj date
   where

--- a/src/Data/Date.purs
+++ b/src/Data/Date.purs
@@ -90,8 +90,8 @@ weekday = unsafePartial \(Date y m d) ->
   in if n == 0 then fromJust (toEnum 7) else fromJust (toEnum n)
 
 -- | Adjusts a date with a Duration in days. The number of days must
--- | fall within the valid range for an `Int` type otherwise `Nothing`
--- | is returned.
+-- | already be an integer and fall within the valid range of values
+-- | for the Int type.
 adjust :: Days -> Date -> Maybe Date
 adjust (Days n) date = fromNumber n >>= flip adj date
   where

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -117,6 +117,8 @@ main = do
   let d1 = unsafePartial fromJust $ Date.canonicalDate <$> toEnum 2016 <*> pure Date.January <*> toEnum 1
   let d2 = unsafePartial fromJust $ Date.canonicalDate <$> toEnum 2016 <*> pure Date.February <*> toEnum 1
   let d3 = unsafePartial fromJust $ Date.canonicalDate <$> toEnum 2016 <*> pure Date.March <*> toEnum 1
+  let d4 = unsafePartial fromJust $ Date.canonicalDate <$> toEnum 2018 <*> pure Date.September <*> toEnum 26
+  let d5 = unsafePartial fromJust $ Date.canonicalDate <$> toEnum 1988 <*> pure Date.August <*> toEnum 15
 
   log "Check that diff behaves as expected"
   assert $ Date.diff d2 d1 == Duration.Days 31.0
@@ -131,6 +133,11 @@ main = do
   assert $ Just (Date.year epochDate) == toEnum 1
   assert $ Date.month epochDate == bottom
   assert $ Date.day epochDate == bottom
+
+  log "Check that adjust behaves as expected"
+  assert $ Date.adjust (Duration.Days 31.0) d1 == Just d2
+  assert $ Date.adjust (Duration.Days 999.0) d1 == Just d4
+  assert $ Date.adjust (Duration.Days (-10000.0)) d1 == Just d5
 
   -- datetime ----------------------------------------------------------------
 

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -137,6 +137,9 @@ main = do
   log "Check that adjust behaves as expected"
   assert $ Date.adjust (Duration.Days 31.0) d1 == Just d2
   assert $ Date.adjust (Duration.Days 999.0) d1 == Just d4
+  assert $ Date.adjust (Duration.Days 10000.0) d5 == Just d1
+  assert $ Date.adjust (Duration.Days (-31.0)) d2 == Just d1
+  assert $ Date.adjust (Duration.Days (- 999.0)) d4 == Just d1
   assert $ Date.adjust (Duration.Days (-10000.0)) d1 == Just d5
 
   -- datetime ----------------------------------------------------------------


### PR DESCRIPTION
This adds:
- instance enumDate :: Enum Date
- adjust :: Days -> Date -> Maybe Date
- tests covering positive and negative day duration and large enough to test across leap years

I initially implemented adjust without adding an enum instance for date, but implementation became quite complicated although possibly more efficient since it can recur with the number of days in a month rather than recur day by day. An enum instance turns out to be very useful.