### PR TITLE
Fix genDate generator frequency

### DIFF
--- a/src/Data/Date/Gen.purs
+++ b/src/Data/Date/Gen.purs
@@ -4,11 +4,21 @@ module Data.Date.Gen
   ) where
 
 import Prelude
-import Control.Monad.Gen (class MonadGen)
-import Data.Date (Date, canonicalDate)
+import Control.Monad.Gen (class MonadGen, chooseInt)
+import Data.Date (Date, adjust, exactDate, isLeapYear)
 import Data.Date.Component.Gen (genDay, genMonth, genWeekday, genYear)
+import Data.Int (toNumber)
+import Data.Maybe (fromJust)
+import Data.Time.Duration (Days(..))
+import Partial.Unsafe (unsafePartial)
 
 -- | Generates a random `Date` between 1st Jan 1900 and 31st Dec 2100,
 -- | inclusive.
 genDate :: forall m. MonadGen m => m Date
-genDate = canonicalDate <$> genYear <*> genMonth <*> genDay
+genDate = do
+  year <- genYear
+  let maxDays = if isLeapYear year then 365 else 364
+  days <- Days <<< toNumber <$> chooseInt 0 maxDays
+  pure $ unsafePartial $ fromJust do
+    janFirst <- exactDate year bottom bottom
+    adjust days janFirst


### PR DESCRIPTION
I discovered that the generator was generating random years but the day
was always December 31st, January 31st, December 1st or January 1st (in
frequency order).
This was because of
https://github.com/purescript/purescript-gen/issues/22 which is now
fixed.
However, reading at the current implementation, there is still a slight
skew toward first days of months following a month with only 30 days or
less. This is because `genYear <*> genMonth <*> genDay` could generate
something like 2020-04-31 which then get converted to 2020-05-01 by
`canonicalDate`. This means that 2020-05-01 has twice as much chance to
get generated as other dates.

The fix is to pick a day number between 1 and 365 (or 366 for leap
years) instead.