### PR TITLE
Implement type-safe constructors for components

### DIFF
--- a/src/Data/Date/Component.purs
+++ b/src/Data/Date/Component.purs
@@ -1,14 +1,27 @@
 module Data.Date.Component
   ( Year
+  , MinYear
+  , MaxYear
+  , year
   , Month(..)
+  , MinMonth
+  , MaxMonth
+  , month
   , Day
+  , MinDay
+  , MaxDay
+  , day
   , Weekday(..)
   ) where
 
 import Prelude
 
 import Data.Enum (class Enum, class BoundedEnum, toEnum, fromEnum, Cardinality(..))
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), fromJust)
+import Data.Reflectable (class Reflectable, reflectType)
+import Prim.Int as PI
+import Prim.Ordering as PO
+import Type.Proxy (Proxy(..))
 
 -- | A year component for a date.
 -- |
@@ -20,22 +33,51 @@ newtype Year = Year Int
 derive newtype instance eqYear :: Eq Year
 derive newtype instance ordYear :: Ord Year
 
+type MinYear :: Int
+type MinYear = -271820
+
+type MaxYear :: Int
+type MaxYear = 275759
+
+-- | Constructs a Year using a type-level integer.
+-- | ```
+-- | year (Proxy :: Proxy 4)
+-- | ```
+year
+  :: forall i lower upper
+   . Reflectable i Int
+  => PI.Add MinYear (-1) lower
+  => PI.Compare i lower PO.GT
+  => PI.Add MinYear 1 upper
+  => PI.Compare i upper PO.LT
+  => Proxy i
+  -> Year
+year p = Year $ reflectType p
+
+-- intentionally not exported
+yearBottom :: Int
+yearBottom = reflectType (Proxy :: Proxy MinYear)
+
+-- intentionally not exported
+yearTop :: Int
+yearTop = reflectType (Proxy :: Proxy MaxYear)
+
 -- Note: these seemingly arbitrary bounds come from relying on JS for date
 -- manipulations, as it only supports date ±100,000,000 days of the Unix epoch.
 -- Using these year values means `Date bottom bottom bottom` is a valid date,
 -- likewise for `top`.
 instance boundedYear :: Bounded Year where
-  bottom = Year (-271820)
-  top = Year 275759
+  bottom = Year yearBottom
+  top = Year yearTop
 
 instance enumYear :: Enum Year where
   succ = toEnum <<< (_ + 1) <<< fromEnum
   pred = toEnum <<< (_ - 1) <<< fromEnum
 
 instance boundedEnumYear :: BoundedEnum Year where
-  cardinality = Cardinality 547580
+  cardinality = Cardinality $ yearTop - yearBottom
   toEnum n
-    | n >= (-271820) && n <= 275759 = Just (Year n)
+    | n >= yearBottom && n <= yearTop = Just (Year n)
     | otherwise = Nothing
   fromEnum (Year n) = n
 
@@ -59,6 +101,39 @@ data Month
 
 derive instance eqMonth :: Eq Month
 derive instance ordMonth :: Ord Month
+
+type MinMonth :: Int
+type MinMonth = 1
+
+type MaxMonth :: Int
+type MaxMonth = 12
+
+-- | Constructs a Month using a type-level integer.
+-- | ```
+-- | month (Proxy :: Proxy 11)
+-- | ```
+month
+  :: forall i lower upper
+   . Reflectable i Int
+  => PI.Add MinMonth (-1) lower
+  => PI.Compare i 0 PO.GT
+  => PI.Add MaxMonth 1 upper
+  => PI.Compare i 13 PO.LT
+  => Proxy i
+  -> Month
+month p = case reflectType p of
+  1 -> January
+  2 -> February
+  3 -> March
+  4 -> April
+  5 -> May
+  6 -> June
+  7 -> July
+  8 -> August
+  9 -> September
+  10 -> October
+  11 -> November
+  _ -> December
 
 instance boundedMonth :: Bounded Month where
   bottom = January
@@ -122,18 +197,47 @@ newtype Day = Day Int
 derive newtype instance eqDay :: Eq Day
 derive newtype instance ordDay :: Ord Day
 
+type MinDay :: Int
+type MinDay = 1
+
+type MaxDay :: Int
+type MaxDay = 31
+
+-- intentionally not exported
+dayBottom :: Int
+dayBottom = reflectType (Proxy :: Proxy MinDay)
+
+-- intentionally not exported
+dayTop :: Int
+dayTop = reflectType (Proxy :: Proxy MaxDay)
+
+-- | Constructs a Day using a type-level integer.
+-- | ```
+-- | day (Proxy :: Proxy 11)
+-- | ```
+day
+  :: forall i lower upper
+   . Reflectable i Int
+  => PI.Add MinDay (-1) lower
+  => PI.Compare i lower PO.GT
+  => PI.Add MaxDay 1 upper
+  => PI.Compare i upper PO.LT
+  => Proxy i
+  -> Day
+day p = Day $ reflectType p
+
 instance boundedDay :: Bounded Day where
-  bottom = Day 1
-  top = Day 31
+  bottom = Day dayBottom
+  top = Day dayTop
 
 instance enumDay :: Enum Day where
   succ = toEnum <<< (_ + 1) <<< fromEnum
   pred = toEnum <<< (_ - 1) <<< fromEnum
 
 instance boundedEnumDay :: BoundedEnum Day where
-  cardinality = Cardinality 31
+  cardinality = Cardinality $ dayTop - dayBottom + 1
   toEnum n
-    | n >= 1 && n <= 31 = Just (Day n)
+    | n >= dayBottom && n <= dayTop = Just (Day n)
     | otherwise = Nothing
   fromEnum (Day n) = n
 

--- a/src/Data/Time/Component.purs
+++ b/src/Data/Time/Component.purs
@@ -1,14 +1,30 @@
 module Data.Time.Component
   ( Hour
+  , MinHour
+  , MaxHour
+  , hour
   , Minute
+  , MinMinute
+  , MaxMinute
+  , minute
   , Second
+  , MinSecond
+  , MaxSecond
+  , second
   , Millisecond
+  , MinMillisecond
+  , MaxMillisecond
+  , millisecond
   ) where
 
 import Prelude
 
 import Data.Enum (class Enum, class BoundedEnum, toEnum, fromEnum, Cardinality(..))
 import Data.Maybe (Maybe(..))
+import Data.Reflectable (class Reflectable, reflectType)
+import Prim.Int as PI
+import Prim.Ordering as PO
+import Type.Proxy (Proxy(..))
 
 -- | An hour component for a time value.
 -- |
@@ -21,18 +37,47 @@ newtype Hour = Hour Int
 derive newtype instance eqHour :: Eq Hour
 derive newtype instance ordHour :: Ord Hour
 
+type MinHour :: Int
+type MinHour = 0
+
+type MaxHour :: Int
+type MaxHour = 23
+
+-- intentionally not exported
+hourBottom :: Int
+hourBottom = reflectType (Proxy :: Proxy 0)
+
+-- intentionally not exported
+hourTop :: Int
+hourTop = reflectType (Proxy :: Proxy 23)
+
+-- | Constructs an Hour using a type-level integer.
+-- | ```
+-- | hour (Proxy :: Proxy 4)
+-- | ```
+hour
+  :: forall i lower upper
+   . Reflectable i Int
+  => PI.Add MinHour (-1) lower
+  => PI.Compare i lower PO.GT
+  => PI.Add MaxHour 1 upper
+  => PI.Compare i upper PO.LT
+  => Proxy i
+  -> Hour
+hour p = Hour $ reflectType p
+
 instance boundedHour :: Bounded Hour where
-  bottom = Hour 0
-  top = Hour 23
+  bottom = Hour hourBottom
+  top = Hour hourTop
 
 instance enumHour :: Enum Hour where
   succ = toEnum <<< (_ + 1) <<< fromEnum
   pred = toEnum <<< (_ - 1) <<< fromEnum
 
 instance boundedEnumHour :: BoundedEnum Hour where
-  cardinality = Cardinality 24
+  cardinality = Cardinality $ hourTop - hourBottom + 1
   toEnum n
-    | n >= 0 && n <= 23 = Just (Hour n)
+    | n >= hourTop && n <= hourTop = Just (Hour n)
     | otherwise = Nothing
   fromEnum (Hour n) = n
 
@@ -50,18 +95,47 @@ newtype Minute = Minute Int
 derive newtype instance eqMinute :: Eq Minute
 derive newtype instance ordMinute :: Ord Minute
 
+type MinMinute :: Int
+type MinMinute = 0
+
+type MaxMinute :: Int
+type MaxMinute = 59
+
+-- intentionally not exported
+minuteBottom :: Int
+minuteBottom = reflectType (Proxy :: Proxy MinMinute)
+
+-- intentionally not exported
+minuteTop :: Int
+minuteTop = reflectType (Proxy :: Proxy MaxMinute)
+
+-- | Constructs a Minute using a type-level integer.
+-- | ```
+-- | minute (Proxy :: Proxy 4)
+-- | ```
+minute
+  :: forall i lower upper
+   . Reflectable i Int
+  => PI.Add MinMinute (-1) lower
+  => PI.Compare i lower PO.GT
+  => PI.Add MaxMinute 1 upper
+  => PI.Compare i upper PO.LT
+  => Proxy i
+  -> Minute
+minute p = Minute $ reflectType p
+
 instance boundedMinute :: Bounded Minute where
-  bottom = Minute 0
-  top = Minute 59
+  bottom = Minute minuteBottom
+  top = Minute minuteTop
 
 instance enumMinute :: Enum Minute where
   succ = toEnum <<< (_ + 1) <<< fromEnum
   pred = toEnum <<< (_ - 1) <<< fromEnum
 
 instance boundedEnumMinute :: BoundedEnum Minute where
-  cardinality = Cardinality 60
+  cardinality = Cardinality $ minuteTop - minuteBottom + 1
   toEnum n
-    | n >= 0 && n <= 59 = Just (Minute n)
+    | n >= minuteBottom && n <= minuteTop = Just (Minute n)
     | otherwise = Nothing
   fromEnum (Minute n) = n
 
@@ -79,18 +153,47 @@ newtype Second = Second Int
 derive newtype instance eqSecond :: Eq Second
 derive newtype instance ordSecond :: Ord Second
 
+type MinSecond :: Int
+type MinSecond = 0
+
+type MaxSecond :: Int
+type MaxSecond = 59
+
+-- intentionally not exported
+secondBottom :: Int
+secondBottom = reflectType (Proxy :: Proxy MinSecond)
+
+-- intentionally not exported
+secondTop :: Int
+secondTop = reflectType (Proxy :: Proxy MaxSecond)
+
+-- | Constructs a Second using a type-level integer.
+-- | ```
+-- | second (Proxy :: Proxy 4)
+-- | ```
+second
+  :: forall i lower upper
+   . Reflectable i Int
+  => PI.Add MinSecond (-1) lower
+  => PI.Compare i lower PO.GT
+  => PI.Add MaxSecond 1 upper
+  => PI.Compare i upper PO.LT
+  => Proxy i
+  -> Second
+second p = Second $ reflectType p
+
 instance boundedSecond :: Bounded Second where
-  bottom = Second 0
-  top = Second 59
+  bottom = Second secondBottom
+  top = Second secondTop
 
 instance enumSecond :: Enum Second where
   succ = toEnum <<< (_ + 1) <<< fromEnum
   pred = toEnum <<< (_ - 1) <<< fromEnum
 
 instance boundedEnumSecond :: BoundedEnum Second where
-  cardinality = Cardinality 60
+  cardinality = Cardinality $ secondTop - secondBottom + 1
   toEnum n
-    | n >= 0 && n <= 59 = Just (Second n)
+    | n >= secondBottom && n <= secondTop = Just (Second n)
     | otherwise = Nothing
   fromEnum (Second n) = n
 
@@ -109,18 +212,47 @@ newtype Millisecond = Millisecond Int
 derive newtype instance eqMillisecond :: Eq Millisecond
 derive newtype instance ordMillisecond :: Ord Millisecond
 
+type MinMillisecond :: Int
+type MinMillisecond = 0
+
+type MaxMillisecond :: Int
+type MaxMillisecond = 999
+
+-- intentionally not exported
+millisecondBottom :: Int
+millisecondBottom = reflectType (Proxy :: Proxy MinSecond)
+
+-- intentionally not exported
+millisecondTop :: Int
+millisecondTop = reflectType (Proxy :: Proxy MaxSecond)
+
+-- | Constructs a Millisecond using a type-level integer.
+-- | ```
+-- | millisecond (Proxy :: Proxy 4)
+-- | ```
+millisecond
+  :: forall i lower upper
+   . Reflectable i Int
+  => PI.Add MinMillisecond (-1) lower
+  => PI.Compare i lower PO.GT
+  => PI.Add MaxMillisecond 1 upper
+  => PI.Compare i upper PO.LT
+  => Proxy i
+  -> Millisecond
+millisecond p = Millisecond $ reflectType p
+
 instance boundedMillisecond :: Bounded Millisecond where
-  bottom = Millisecond 0
-  top = Millisecond 999
+  bottom = Millisecond millisecondBottom
+  top = Millisecond millisecondTop
 
 instance enumMillisecond :: Enum Millisecond where
   succ = toEnum <<< (_ + 1) <<< fromEnum
   pred = toEnum <<< (_ - 1) <<< fromEnum
 
 instance boundedEnumMillisecond :: BoundedEnum Millisecond where
-  cardinality = Cardinality 1000
+  cardinality = Cardinality $ millisecondTop - millisecondBottom + 1
   toEnum n
-    | n >= 0 && n <= 999 = Just (Millisecond n)
+    | n >= millisecondBottom && n <= millisecondTop = Just (Millisecond n)
     | otherwise = Nothing
   fromEnum (Millisecond n) = n
 


### PR DESCRIPTION
**Description of the change**

Fixes #96. I did not implement an `exactDate'` (see `canonicalDate'` for comparison). Since we don't currently have a `Prim.Int (class Mod)`, we can't define a type-level computation that guarantees that a given day falls within a given year-month combo. So, the best we could write right now would be:

```purs
exactDate'
  :: forall year month day 
   . Reflectable year Int
  => PI.Compare year (-271821) PO.GT
  => PI.Compare year 275760 PO.LT
  => Reflectable month Int
  => PI.Compare month 0 PO.GT
  => PI.Compare month 13 PO.LT
  => Reflectable day Int
  => PI.Compare day 0 PO.GT
  => PI.Compare day 32 PO.LT
  => Proxy year
  -> Proxy month
  -> Proxy day
  -> Date
exactDate' y m d = Date (DC.year y) (DC.month m) (DC.day d)
```

If we implemented `exactDate'` as it is defined above right now, and `Prim.Int (class Mod)` is implemented later in the `0.15.x` PureScript series, changing the definition would be a breaking change. But if we leave it out for now, we can add it as a non-breaking change later as:
```purs
exactDate'
  :: forall year month day maxDay dayUpper
   . Reflectable year Int
  ...
  => MaxDay year month maxDay
  => PI.Add maxDay 1 dayUpper
  => PI.Compare day 0 PO.GT
  => PI.Compare day dayUpper PO.LT
  => Proxy year
  -> Proxy month
  -> Proxy day
  -> Date
exactDate' y m d = Date (DC.year y) (DC.month m) (DC.day d)
```

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
